### PR TITLE
CPU: Interpret value 12 as being ARM64 (rather than Apple Silicon)

### DIFF
--- a/ModernWinver/MainWindow.xaml.cs
+++ b/ModernWinver/MainWindow.xaml.cs
@@ -380,7 +380,7 @@ namespace ModernWinver
                 case "9":
                     vals.Arch = "AMD64"; break;
                 case "12":
-                    vals.Arch = "Probably Apple Silicon"; break;
+                    vals.Arch = "ARM64"; break;
                 default:
                     vals.Arch = "Unknown"; break;
             }


### PR DESCRIPTION
This is an assumption so you could change it to "Probably ARM64" if you want.
I have no idea why the Raspberry Pi 4 reports itself as 5 (ARM) correctly
but both the Surface Pro X and Lumia 950 XL are giving 12 which is causing incorrect results.

![image](https://user-images.githubusercontent.com/14004943/117600339-a25f1e80-b143-11eb-9746-9695ea965d2b.png)
